### PR TITLE
fix(terminal): attach dropped screenshots

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { extname, join } from 'node:path';
 import * as vscode from 'vscode';
 import { listWorktrees } from './git/worktrees';
 import { RepositoryTreeProvider, type RepositoryTreeNode } from './tree/repositoryTree';
@@ -489,6 +489,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   let lastRevealedActiveTerminalSessionName: string | undefined;
+  let activeTerminalBeforeTabChange = activeDeckTerminal();
   const revealActiveTerminalAfterNavigation = async () => {
     const activeTerminalSessionName = activeDeckTerminal()?.sessionName;
     // VS Code also emits tab changes for Deck's agent icon/title churn, not
@@ -566,11 +567,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       await writeDeckConf(context, tmuxOptions);
       await applyDeckTmuxOptionsIfServerRunning(tmux, tmuxOptions, tmuxAvailability.available);
     }),
-    vscode.window.tabGroups.onDidChangeTabs(async () => {
+    vscode.window.tabGroups.onDidChangeTabs(async (event) => {
+      const previousTerminal = activeTerminalBeforeTabChange
+        ?? event.changed.map(deckTerminalFromTab).find((terminal) => terminal !== undefined);
+      activeTerminalBeforeTabChange = activeDeckTerminal();
+
+      if (previousTerminal) {
+        const openedImageTab = event.opened.find((tab) => externalPngUri(tab) !== undefined);
+        const imageUri = openedImageTab && externalPngUri(openedImageTab);
+        if (openedImageTab && imageUri) {
+          const attached = await terminalEditorProvider.attachImageFile(previousTerminal.sessionName, imageUri);
+          if (attached) await vscode.window.tabGroups.close(openedImageTab, true);
+          activeTerminalBeforeTabChange = activeDeckTerminal();
+        }
+      }
+
       await markActiveTerminalRead(agentStatuses);
       await revealActiveTerminalAfterNavigation();
     }),
     vscode.window.tabGroups.onDidChangeTabGroups(async () => {
+      activeTerminalBeforeTabChange = activeDeckTerminal();
       await markActiveTerminalRead(agentStatuses);
       await revealActiveTerminalAfterNavigation();
     }),
@@ -883,7 +899,11 @@ async function openAgentStatusTerminal(
 
 function activeDeckTerminal(): { sessionName: string; worktreePath: string } | undefined {
   const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
-  const input = activeTab?.input as { viewType?: unknown; uri?: vscode.Uri } | undefined;
+  return activeTab ? deckTerminalFromTab(activeTab) : undefined;
+}
+
+function deckTerminalFromTab(tab: vscode.Tab): { sessionName: string; worktreePath: string } | undefined {
+  const input = tab.input as { viewType?: unknown; uri?: vscode.Uri } | undefined;
   if (input?.viewType !== terminalEditorViewType || !input.uri) return undefined;
 
   try {
@@ -891,6 +911,13 @@ function activeDeckTerminal(): { sessionName: string; worktreePath: string } | u
   } catch {
     return undefined;
   }
+}
+
+function externalPngUri(tab: vscode.Tab): vscode.Uri | undefined {
+  const uri = (tab.input as { uri?: vscode.Uri } | undefined)?.uri;
+  if (!uri || uri.scheme !== 'file' || extname(uri.fsPath).toLowerCase() !== '.png') return undefined;
+  if (vscode.workspace.getWorkspaceFolder(uri)) return undefined;
+  return uri;
 }
 
 async function markActiveTerminalRead(

--- a/src/terminal/terminalEditorProvider.ts
+++ b/src/terminal/terminalEditorProvider.ts
@@ -1,4 +1,9 @@
 import * as vscode from 'vscode';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
 import { resolveTerminalTabIcon } from '../agent/agentIconResolver';
 import type { AgentName } from '../agent/agentTypes';
 import { SessionUriCodec } from './sessionUriCodec';
@@ -48,6 +53,16 @@ interface ClearHistoryMessage {
   type: 'clearHistory';
 }
 
+interface ImageDropErrorMessage {
+  type: 'imageDropError';
+  payload: string;
+}
+
+interface ImageDropMessage {
+  type: 'imageDrop';
+  payload: string;
+}
+
 interface TerminalConfig {
   fontFamily: string;
   fontSize: number;
@@ -60,7 +75,9 @@ type TerminalWebviewMessage =
   | ResizeMessage
   | ExitMessage
   | FocusedMessage
-  | ClearHistoryMessage;
+  | ClearHistoryMessage
+  | ImageDropMessage
+  | ImageDropErrorMessage;
 
 type TerminalTabIconPath = vscode.IconPath;
 
@@ -78,9 +95,35 @@ export interface TerminalTransportLike {
 export type TerminalTransportFactory = () => TerminalTransportLike;
 export type TerminalEditorDisposeHandler = (sessionName: string) => Promise<void> | void;
 export type TerminalEditorTitleChangeHandler = (sessionName: string) => Promise<void> | void;
+export type ImageClipboardWriter = (png: Uint8Array) => Promise<void>;
+
+const execFileAsync = promisify(execFile);
+
+async function writePngToSystemClipboard(png: Uint8Array): Promise<void> {
+  if (process.platform !== 'darwin') {
+    throw new Error('native image clipboard fallback is currently available only on macOS');
+  }
+  const directory = await mkdtemp(join(tmpdir(), 'deck-image-drop-'));
+  const imagePath = join(directory, 'image.png');
+  try {
+    await writeFile(imagePath, png);
+    await execFileAsync('/usr/bin/osascript', [
+      '-e',
+      'on run argv',
+      '-e',
+      'set the clipboard to (read POSIX file (item 1 of argv) as «class PNGf»)',
+      '-e',
+      'end run',
+      imagePath,
+    ]);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
 
 export class TerminalEditorProvider implements vscode.CustomReadonlyEditorProvider<TerminalDocument> {
   private readonly panels = new Map<string, vscode.WebviewPanel>();
+  private readonly transports = new Map<string, TerminalTransportLike>();
   private readonly readyPanels = new Set<vscode.WebviewPanel>();
   private readonly pendingTerminalFocus = new Set<string>();
   // Sessions whose decoration we skipped while hidden — re-applied when shown.
@@ -106,6 +149,7 @@ export class TerminalEditorProvider implements vscode.CustomReadonlyEditorProvid
     private readonly beforeReattach: () => Promise<void> = () => Promise.resolve(),
     private readonly resolveTerminalAgentName: (sessionName: string) => Promise<AgentName | undefined> = async () =>
       undefined,
+    private readonly writeImageToClipboard: ImageClipboardWriter = writePngToSystemClipboard,
   ) {
     this.configChangeSubscription = vscode.workspace.onDidChangeConfiguration((event) => {
       const fontKeys = [
@@ -150,6 +194,34 @@ export class TerminalEditorProvider implements vscode.CustomReadonlyEditorProvid
     return this.panels.get(sessionName);
   }
 
+  async attachImageFile(sessionName: string, uri: vscode.Uri): Promise<boolean> {
+    const panel = this.panels.get(sessionName);
+    const transport = this.transports.get(sessionName);
+    if (!panel || !transport) return false;
+
+    try {
+      const png = await vscode.workspace.fs.readFile(uri);
+      const encodedLimit = 44 * 1024 * 1024;
+      if (png.length * 4 / 3 > encodedLimit) {
+        throw new Error('the image is too large');
+      }
+      const signature = [137, 80, 78, 71, 13, 10, 26, 10];
+      if (png.length < signature.length || signature.some((byte, index) => png[index] !== byte)) {
+        throw new Error('invalid PNG data');
+      }
+
+      await this.writeImageToClipboard(png);
+      panel.reveal(panel.viewColumn, false);
+      transport.write('\x16');
+      this.focusTerminal(sessionName);
+      return true;
+    } catch (error: unknown) {
+      const detail = error instanceof Error ? error.message : String(error);
+      void vscode.window.showErrorMessage(`Deck could not attach the dropped image: ${detail}`);
+      return false;
+    }
+  }
+
   focusTerminal(sessionName: string): void {
     const panel = this.panels.get(sessionName);
     if (!panel) return;
@@ -183,6 +255,7 @@ export class TerminalEditorProvider implements vscode.CustomReadonlyEditorProvid
     this.panels.set(document.sessionName, panel);
     this.activePanel = panel;
     const transport = this.transportFactory();
+    this.transports.set(document.sessionName, transport);
     const transportDisposables: vscode.Disposable[] = [];
 
     panel.webview.options = {
@@ -236,6 +309,28 @@ export class TerminalEditorProvider implements vscode.CustomReadonlyEditorProvid
         }
         if (message.type === 'resize') transport.resize(message.cols, message.rows);
         if (message.type === 'clearHistory') transport.clearHistory();
+        if (message.type === 'imageDrop') {
+          const encodedLimit = 44 * 1024 * 1024;
+          if (message.payload.length > encodedLimit) {
+            void vscode.window.showErrorMessage('Deck could not attach the dropped image: the image is too large');
+            return;
+          }
+          const png = Buffer.from(message.payload, 'base64');
+          const signature = [137, 80, 78, 71, 13, 10, 26, 10];
+          if (png.length < signature.length || signature.some((byte, index) => png[index] !== byte)) {
+            void vscode.window.showErrorMessage('Deck could not attach the dropped image: invalid PNG data');
+            return;
+          }
+          void this.writeImageToClipboard(png)
+            .then(() => transport.write('\x16'))
+            .catch((error: unknown) => {
+              const detail = error instanceof Error ? error.message : String(error);
+              void vscode.window.showErrorMessage(`Deck could not attach the dropped image: ${detail}`);
+            });
+        }
+        if (message.type === 'imageDropError') {
+          void vscode.window.showErrorMessage(`Deck could not attach the dropped image: ${message.payload}`);
+        }
         if (message.type === 'focused') this.activePanel = panel;
         if (message.type === 'exit') panel.dispose();
       }),
@@ -244,6 +339,7 @@ export class TerminalEditorProvider implements vscode.CustomReadonlyEditorProvid
     panel.onDidDispose(() => {
       if (this.panels.get(document.sessionName) === panel) {
         this.panels.delete(document.sessionName);
+        this.transports.delete(document.sessionName);
         this.staleDecorations.delete(document.sessionName);
         this.pendingTerminalFocus.delete(document.sessionName);
       }
@@ -654,6 +750,77 @@ export class TerminalEditorProvider implements vscode.CustomReadonlyEditorProvid
         if (text) vscode.postMessage({ type: 'input', payload: text });
       }
 
+      async function imageAsClipboardPng(file) {
+        if (file.type === 'image/png') return file;
+        const bitmap = await createImageBitmap(file);
+        try {
+          const canvas = document.createElement('canvas');
+          canvas.width = bitmap.width;
+          canvas.height = bitmap.height;
+          const context = canvas.getContext('2d');
+          if (!context) throw new Error('the browser could not create an image canvas');
+          context.drawImage(bitmap, 0, 0);
+          const png = await new Promise((resolve, reject) => {
+            canvas.toBlob(
+              (blob) => blob ? resolve(blob) : reject(new Error('the browser could not convert the image to PNG')),
+              'image/png',
+            );
+          });
+          return png;
+        } finally {
+          bitmap.close();
+        }
+      }
+
+      async function attachDroppedImage(file) {
+        try {
+          const png = await imageAsClipboardPng(file);
+          if (navigator.clipboard.write && typeof ClipboardItem !== 'undefined') {
+            try {
+              await navigator.clipboard.write([new ClipboardItem({ 'image/png': png })]);
+              // Codex and Claude Code both use Ctrl+V as their native image-attach
+              // action. Keeping that final hop native preserves their validation,
+              // resizing and prompt rendering instead of teaching Deck either
+              // agent's attachment protocol.
+              vscode.postMessage({ type: 'input', payload: '\\x16' });
+              return;
+            } catch (_) {
+              // VS Code webviews can reject Clipboard.write when the outer
+              // document owns focus. The extension host fallback below is not
+              // focus-gated and preserves the same native agent attach hop.
+            }
+          }
+          const bytes = new Uint8Array(await png.arrayBuffer());
+          let binary = '';
+          const chunkSize = 0x8000;
+          for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+            binary += String.fromCharCode(...bytes.subarray(offset, offset + chunkSize));
+          }
+          vscode.postMessage({ type: 'imageDrop', payload: btoa(binary) });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          vscode.postMessage({ type: 'imageDropError', payload: message });
+        }
+      }
+
+      const imageFilePattern = /\\.(?:png|jpe?g|gif|webp|bmp|tiff?|heic|heif|avif)$/i;
+
+      function isImageFile(file) {
+        return file.type.startsWith('image/') || imageFilePattern.test(file.name);
+      }
+
+      function filesFromDrop(dataTransfer) {
+        const files = Array.from(dataTransfer?.files || []);
+        for (const item of Array.from(dataTransfer?.items || [])) {
+          if (item.kind !== 'file') continue;
+          const file = item.getAsFile();
+          if (file && !files.some((candidate) => candidate === file || (
+            candidate.name === file.name && candidate.size === file.size
+          ))) files.push(file);
+        }
+        return files;
+      }
+
       function openFindWidget() {
         findWidget.style.display = 'flex';
         findInput.focus();
@@ -695,6 +862,33 @@ export class TerminalEditorProvider implements vscode.CustomReadonlyEditorProvid
         // Claude Code's clipboard fallback turns into a second image.
         event.stopPropagation();
         vscode.postMessage({ type: 'input', payload: '\\x16' });
+      }, true);
+      terminalElement.addEventListener('dragover', (event) => {
+        const items = Array.from(event.dataTransfer?.items || []);
+        // Fresh macOS screenshots arrive as promised files. During dragover
+        // their MIME type is often blank and their filename is not exposed yet,
+        // so the image MIME prefix alone misses the exact drop Deck needs to claim.
+        const hasPossibleImage = items.some((item) => item.kind === 'file' && (
+          item.type === '' || item.type.startsWith('image/')
+        )) || Array.from(event.dataTransfer?.types || []).includes('Files');
+        if (!hasPossibleImage) return;
+        event.preventDefault();
+        event.dataTransfer.dropEffect = 'copy';
+      }, true);
+      terminalElement.addEventListener('drop', (event) => {
+        const images = filesFromDrop(event.dataTransfer).filter(isImageFile);
+        if (images.length === 0) return;
+        event.preventDefault();
+        // Keep VS Code from treating the same drop as an editor-open request.
+        event.stopPropagation();
+        if (images.length > 1) {
+          vscode.postMessage({
+            type: 'imageDropError',
+            payload: 'drop one image at a time',
+          });
+          return;
+        }
+        void attachDroppedImage(images[0]);
       }, true);
       document.addEventListener('click', hideContextMenu);
       document.addEventListener('keydown', (event) => {

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -82,6 +82,7 @@ const vscodeState = vi.hoisted(() => ({
   onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
   onDidChangeTabGroups: vi.fn(() => ({ dispose: vi.fn() })),
   onDidChangeTabs: vi.fn(() => ({ dispose: vi.fn() })),
+  closeTab: vi.fn(async () => true),
   onDidChangeWindowState: vi.fn(() => ({ dispose: vi.fn() })),
   windowFocused: true,
   onDidChangeWorkspaceFolders: vi.fn(() => ({ dispose: vi.fn() })),
@@ -157,6 +158,7 @@ const vscodeState = vi.hoisted(() => ({
   ),
   showTextDocument: vi.fn(),
   workspaceFsStat: vi.fn(async () => ({})),
+  workspaceFsReadFile: vi.fn(async () => new Uint8Array()),
   treeViewSelection: [] as unknown[],
 }));
 
@@ -225,6 +227,7 @@ vi.mock('vscode', () => ({
         activeTabGroup: { activeTab: vscodeState.activeTab },
         onDidChangeTabGroups: vscodeState.onDidChangeTabGroups,
         onDidChangeTabs: vscodeState.onDidChangeTabs,
+        close: vscodeState.closeTab,
       };
     },
   },
@@ -253,7 +256,12 @@ vi.mock('vscode', () => ({
     }),
     fs: {
       stat: vscodeState.workspaceFsStat,
+      readFile: vscodeState.workspaceFsReadFile,
     },
+    getWorkspaceFolder: (uri: { fsPath?: string }) =>
+      vscodeState.workspaceFolders.find((folder) =>
+        uri.fsPath === folder.uri.fsPath || uri.fsPath?.startsWith(`${folder.uri.fsPath}/`),
+      ),
     onDidChangeConfiguration: (listener: (event: { affectsConfiguration(section: string): boolean }) => unknown) => {
       vscodeState.onDidChangeConfiguration(listener);
       vscodeState.configListeners.push(listener);
@@ -670,6 +678,7 @@ describe('activate', () => {
     }]);
     vscodeState.onDidChangeTabGroups.mockClear();
     vscodeState.onDidChangeTabs.mockClear();
+    vscodeState.closeTab.mockClear();
     vscodeState.onDidChangeWindowState.mockClear();
     vscodeState.windowFocused = true;
     vscodeState.tabGroups = [];

--- a/test/terminalEditorProvider.test.ts
+++ b/test/terminalEditorProvider.test.ts
@@ -17,6 +17,12 @@ vi.mock('vscode', () => ({
       get: (key: string, defaultValue: unknown) => cfg[section]?.[key] ?? defaultValue,
     }),
     onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+    fs: {
+      readFile: vi.fn(),
+    },
+  },
+  window: {
+    showErrorMessage: vi.fn(),
   },
 }));
 
@@ -30,6 +36,8 @@ function panel() {
     dispose: vi.fn(),
     title: '',
     visible: true,
+    viewColumn: 1,
+    reveal: vi.fn(),
     webview: {
       options: {},
       html: '',
@@ -720,6 +728,114 @@ describe('TerminalEditorProvider', () => {
     expect(terminalPanel.webview.html).toContain("navigator.clipboard.read()");
     expect(terminalPanel.webview.html).toContain("item.types.some((type) => type.startsWith('image/'))");
     expect(terminalPanel.webview.html).toContain("navigator.clipboard.readText()");
+  });
+
+  it('renders image drop attachment without letting VS Code open the dropped file', () => {
+    const terminalPanel = panel();
+    const { provider, document } = providerDocument();
+
+    provider.resolveCustomEditor(document, terminalPanel as never);
+
+    expect(terminalPanel.webview.html).toContain("terminalElement.addEventListener('dragover'");
+    expect(terminalPanel.webview.html).toContain("terminalElement.addEventListener('drop'");
+    expect(terminalPanel.webview.html).toContain("item.type === '' || item.type.startsWith('image/')");
+    expect(terminalPanel.webview.html).toContain("includes('Files')");
+    expect(terminalPanel.webview.html).toContain("filesFromDrop(event.dataTransfer).filter(isImageFile)");
+    expect(terminalPanel.webview.html).toContain("imageFilePattern.test(file.name)");
+    expect(terminalPanel.webview.html).toContain("navigator.clipboard.write([new ClipboardItem({ 'image/png': png })])");
+    expect(terminalPanel.webview.html).toContain("type: 'imageDrop', payload: btoa(binary)");
+    expect(terminalPanel.webview.html).toContain("void attachDroppedImage(images[0])");
+  });
+
+  it('uses the native clipboard fallback before forwarding the agent image-attach key', async () => {
+    let receiveMessage: ((message: { type: string; payload: string }) => void) | undefined;
+    const terminalPanel = panel();
+    terminalPanel.webview.onDidReceiveMessage.mockImplementation(
+      (handler: (message: { type: string; payload: string }) => void) => {
+        receiveMessage = handler;
+        return { dispose: vi.fn() };
+      },
+    );
+    const terminalBridge = bridge();
+    const writeImage = vi.fn(async () => undefined);
+    const provider = new TerminalEditorProvider(
+      { fsPath: '/extension' } as never,
+      '/extension/resources/deck.conf',
+      undefined,
+      () => terminalBridge,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      writeImage,
+    );
+    const document = provider.openCustomDocument({
+      scheme: 'deck-terminal',
+      path: '/work/alpha-main/term-1',
+    } as never);
+    const png = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3]);
+
+    provider.resolveCustomEditor(document, terminalPanel as never);
+    receiveMessage?.({ type: 'imageDrop', payload: png.toString('base64') });
+    await flush();
+
+    expect(writeImage).toHaveBeenCalledWith(png);
+    expect(terminalBridge.write).toHaveBeenCalledWith('\x16');
+  });
+
+  it('recovers an external PNG opened by VS Code and attaches it to the target terminal', async () => {
+    const png = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3]);
+    vi.mocked(vscode.workspace.fs.readFile).mockResolvedValue(png);
+    const terminalBridge = bridge();
+    const writeImage = vi.fn(async () => undefined);
+    const provider = new TerminalEditorProvider(
+      { fsPath: '/extension' } as never,
+      '/extension/resources/deck.conf',
+      undefined,
+      () => terminalBridge,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      writeImage,
+    );
+    const terminalPanel = panel();
+    const document = provider.openCustomDocument({
+      scheme: 'deck-terminal',
+      path: '/work/alpha-main/term-1',
+    } as never);
+    provider.resolveCustomEditor(document, terminalPanel as never);
+
+    const attached = await provider.attachImageFile(
+      'wt-_work_alpha-main__term-1',
+      { scheme: 'file', fsPath: '/tmp/Screenshot.png' } as never,
+    );
+
+    expect(attached).toBe(true);
+    expect(writeImage).toHaveBeenCalledWith(png);
+    expect(terminalPanel.reveal).toHaveBeenCalledWith(1, false);
+    expect(terminalBridge.write).toHaveBeenCalledWith('\x16');
+  });
+
+  it('shows a visible error when a dropped image cannot be attached', () => {
+    let receiveMessage: ((message: { type: string; payload: string }) => void) | undefined;
+    const terminalPanel = panel();
+    terminalPanel.webview.onDidReceiveMessage.mockImplementation(
+      (handler: (message: { type: string; payload: string }) => void) => {
+        receiveMessage = handler;
+        return { dispose: vi.fn() };
+      },
+    );
+    const { provider, document } = providerDocument();
+
+    provider.resolveCustomEditor(document, terminalPanel as never);
+    receiveMessage?.({ type: 'imageDropError', payload: 'clipboard denied' });
+
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      'Deck could not attach the dropped image: clipboard denied',
+    );
   });
 
   it('maps Shift+Enter to an ESC+CR newline sequence', () => {


### PR DESCRIPTION
## Summary

- accept image files dropped onto Deck terminal webviews and forward them through the coding agent's native Ctrl+V image-attachment path
- fall back to the macOS system clipboard when the webview clipboard API is unavailable
- recover external PNG drops intercepted by VS Code's editor drop overlay, attach them to the previously active Deck terminal, and close the accidentally opened image tab
- leave images inside the current workspace alone so normal asset editing is unchanged

## Root cause

Deck terminals are custom editor webviews. For external macOS file drops, VS Code can create its editor drop overlay before the event reaches the webview, opening the screenshot as a new editor tab. The extension therefore needs both an in-webview handler and a custom-editor-level recovery path.

## Verification

- `npm test -- --run test/extension.test.ts test/terminalEditorProvider.test.ts` (86 tests passed)
- `npm run typecheck`
- `npm run build`
- manually verified with a real macOS screenshot dragged into a Deck terminal running a coding-agent session
