### PR TITLE
fix(terminal): replay pane terminal modes on reattach so TUIs keep mouse reporting

### DIFF
--- a/docs/adr/0012-terminal-transport-tmux-control-mode.md
+++ b/docs/adr/0012-terminal-transport-tmux-control-mode.md
@@ -82,6 +82,15 @@ Alternatives considered:
    an empty screen, and mixing snapshot + seed duplicates content (seen
    in QA). `deck.conf` sizes tmux's `history-limit` to the same cap so
    tmux does not retain pane history Deck can never surface.
+   The seed also replays the pane's terminal *modes* — mouse reporting
+   (`?1000/1002/1003/1006`), cursor visibility, application cursor
+   keys/keypad, bracketed paste — read from tmux's per-pane format flags
+   (`mouse_*_flag`, `cursor_flag`, …) in the same `list-panes -F` that
+   discovers the pane id. A fresh xterm starts with every mode off and a
+   running TUI sets them once at startup, so without the replay a
+   Terminal reattached after a Switch or reload keeps its process but
+   loses mouse input; the post-seed SIGWINCH repaint does not recover
+   them because TUIs do not re-send modes on redraw.
 
 6. **Exit semantics are preserved.** Child-process exit (and the
    preceding `%exit`) maps to `onExit(code)` exactly as node-pty's exit

--- a/src/terminal/tmuxControlClient.ts
+++ b/src/terminal/tmuxControlClient.ts
@@ -25,6 +25,29 @@ interface PendingReply {
   seed?: boolean;
 }
 
+// Terminal modes a TUI sets once at startup and that a freshly created xterm
+// starts without (mouse reporting, hidden cursor, application cursor keys /
+// keypad, bracketed paste). tmux tracks them per pane and exposes each as a
+// format flag; the seed replays the ones that are on so a reattached tab
+// behaves like the tab the TUI originally configured — a redraw (SIGWINCH)
+// alone does not make TUIs re-send them. Format name, flag value that needs
+// a replay, and the sequence that sets it.
+const PANE_MODES: ReadonlyArray<[format: string, whenFlagIs: '0' | '1', sequence: string]> = [
+  ['mouse_standard_flag', '1', '\x1b[?1000h'],
+  ['mouse_button_flag', '1', '\x1b[?1002h'],
+  ['mouse_all_flag', '1', '\x1b[?1003h'],
+  ['mouse_sgr_flag', '1', '\x1b[?1006h'],
+  ['cursor_flag', '0', '\x1b[?25l'],
+  ['keypad_cursor_flag', '1', '\x1b[?1h'],
+  ['keypad_flag', '1', '\x1b='],
+  ['bracket_paste_flag', '1', '\x1b[?2004h'],
+];
+
+// Comma-separated so a format tmux does not know (older than our preflight
+// floor may lack bracket_paste_flag) expands to an empty field instead of
+// shifting the ones after it.
+const PANE_STATE_FORMAT = ['#{pane_id}', '#{cursor_y}', '#{cursor_x}', '#{alternate_on}', ...PANE_MODES.map(([format]) => `#{${format}}`)].join(',');
+
 export class TmuxControlClient {
   private child: TmuxControlChild | undefined;
   private startPromise: Promise<void> | undefined;
@@ -97,14 +120,14 @@ export class TmuxControlClient {
     // without this the cursor sits at end-of-content until the next redraw. The
     // canonical control-mode client (iTerm2) likewise reads cursor_x/cursor_y as
     // pane state apart from the content.
-    const fields = (await this.command(`list-panes -s -t ${controlModeTarget(sessionName)} -F "#{pane_id} #{cursor_y} #{cursor_x} #{alternate_on}"`))
+    const fields = (await this.command(`list-panes -s -t ${controlModeTarget(sessionName)} -F "${PANE_STATE_FORMAT}"`))
       .trim()
       .split('\n')
       .filter(Boolean);
     if (fields.length !== 1) {
       throw new Error(`expected exactly one tmux pane, got ${fields.length}`);
     }
-    const [paneId, cursorRow, cursorColumn, alternateOn] = fields[0].split(/\s+/);
+    const [paneId, cursorRow, cursorColumn, alternateOn, ...modeFlags] = fields[0].split(',');
     this.paneId = paneId;
 
     // A full-screen TUI (Claude, vim, …) runs in the terminal's alternate screen.
@@ -113,8 +136,12 @@ export class TmuxControlClient {
     // fills xterm's alternate buffer; otherwise the snapshot lands in the normal
     // buffer and bleeds through (stale, with its colours) when the TUI exits the
     // alt screen. The matching exit (\x1b[?1049l) arrives live when the TUI quits.
-    if (alternateOn === '1') {
-      for (const handler of this.seedHandlers) handler('\x1b[?1049h\x1b[H');
+    // The pane's other modes ride along (see PANE_MODES); their matching resets
+    // likewise arrive live from the TUI.
+    const modes = (alternateOn === '1' ? '\x1b[?1049h\x1b[H' : '')
+      + PANE_MODES.map(([, whenFlagIs, sequence], i) => (modeFlags[i] === whenFlagIs ? sequence : '')).join('');
+    if (modes) {
+      for (const handler of this.seedHandlers) handler(modes);
     }
     // -q: a pane that died between attach and capture is not a startup error.
     // -N: preserve trailing spaces (tmux >= 3.1, our preflight floor).

--- a/test/tmuxControlClient.test.ts
+++ b/test/tmuxControlClient.test.ts
@@ -35,7 +35,7 @@ describe('TmuxControlClient', () => {
       '/work/repo',
     ], { cwd: '/work/repo', stdio: 'pipe' });
     expect(child.writes).toEqual([
-      'list-panes -s -t "=wt-_work_repo__term-1" -F "#{pane_id} #{cursor_y} #{cursor_x} #{alternate_on}"\n',
+      'list-panes -s -t "=wt-_work_repo__term-1" -F "#{pane_id},#{cursor_y},#{cursor_x},#{alternate_on},#{mouse_standard_flag},#{mouse_button_flag},#{mouse_all_flag},#{mouse_sgr_flag},#{cursor_flag},#{keypad_cursor_flag},#{keypad_flag},#{bracket_paste_flag}"\n',
       'capture-pane -p -e -q -J -N -S -5000\n',
     ]);
   });
@@ -54,7 +54,7 @@ describe('TmuxControlClient', () => {
     await started;
 
     expect(child.writes[0]).toBe(
-      'list-panes -s -t "=wt-_work_my \\"repo\\"\\\\branch__term-1" -F "#{pane_id} #{cursor_y} #{cursor_x} #{alternate_on}"\n',
+      'list-panes -s -t "=wt-_work_my \\"repo\\"\\\\branch__term-1" -F "#{pane_id},#{cursor_y},#{cursor_x},#{alternate_on},#{mouse_standard_flag},#{mouse_button_flag},#{mouse_all_flag},#{mouse_sgr_flag},#{cursor_flag},#{keypad_cursor_flag},#{keypad_flag},#{bracket_paste_flag}"\n',
     );
   });
 
@@ -101,8 +101,8 @@ describe('TmuxControlClient', () => {
     const started = client.start('wt-_work_repo__term-1', '/work/repo', 5000);
     child.emitStdout('%begin 1 1 0\n%end 1 1 0\n');
     await untilWrites(child, 1);
-    // pane id + cursor_y + cursor_x
-    child.emitStdout('%begin 1 2 1\n%0 3 7\n%end 1 2 1\n');
+    // pane id, cursor_y, cursor_x
+    child.emitStdout('%begin 1 2 1\n%0,3,7\n%end 1 2 1\n');
     await untilWrites(child, 2);
     child.emitStdout('%begin 1 3 1\nhistory\n%end 1 3 1\n');
     await started;
@@ -120,8 +120,8 @@ describe('TmuxControlClient', () => {
     const started = client.start('wt-_work_repo__term-1', '/work/repo', 5000);
     child.emitStdout('%begin 1 1 0\n%end 1 1 0\n');
     await untilWrites(child, 1);
-    // pane id + cursor_y + cursor_x + alternate_on=1
-    child.emitStdout('%begin 1 2 1\n%0 3 7 1\n%end 1 2 1\n');
+    // pane id, cursor_y, cursor_x, alternate_on=1
+    child.emitStdout('%begin 1 2 1\n%0,3,7,1\n%end 1 2 1\n');
     await untilWrites(child, 2);
     child.emitStdout('%begin 1 3 1\nframe\n%end 1 3 1\n');
     await started;
@@ -129,6 +129,47 @@ describe('TmuxControlClient', () => {
     // Alt-screen enter first (so the captured frame fills xterm's alternate
     // buffer, not the normal one), then the frame, then the cursor reposition.
     expect(seeds).toEqual(['\x1b[?1049h\x1b[H', 'frame', '\x1b[4;8H']);
+  });
+
+  it('replays the pane terminal modes a running TUI set so a reattached tab keeps mouse reporting', async () => {
+    const child = fakeChild();
+    const client = new TmuxControlClient('/ext/resources/deck.conf', vi.fn(() => child));
+    const seeds: string[] = [];
+    client.onSeed((seed) => seeds.push(seed));
+
+    const started = client.start('wt-_work_repo__term-1', '/work/repo', 5000);
+    child.emitStdout('%begin 1 1 0\n%end 1 1 0\n');
+    await untilWrites(child, 1);
+    // alt screen on; mouse button+SGR tracking on (standard/all off); cursor
+    // hidden; application cursor keys + keypad on; bracketed paste on.
+    child.emitStdout('%begin 1 2 1\n%0,3,7,1,0,1,0,1,0,1,1,1\n%end 1 2 1\n');
+    await untilWrites(child, 2);
+    child.emitStdout('%begin 1 3 1\nframe\n%end 1 3 1\n');
+    await started;
+
+    expect(seeds).toEqual([
+      '\x1b[?1049h\x1b[H\x1b[?1002h\x1b[?1006h\x1b[?25l\x1b[?1h\x1b=\x1b[?2004h',
+      'frame',
+      '\x1b[4;8H',
+    ]);
+  });
+
+  it('tolerates a tmux that lacks a mode format (empty field) without shifting the others', async () => {
+    const child = fakeChild();
+    const client = new TmuxControlClient('/ext/resources/deck.conf', vi.fn(() => child));
+    const seeds: string[] = [];
+    client.onSeed((seed) => seeds.push(seed));
+
+    const started = client.start('wt-_work_repo__term-1', '/work/repo', 5000);
+    child.emitStdout('%begin 1 1 0\n%end 1 1 0\n');
+    await untilWrites(child, 1);
+    // Normal screen, SGR mouse on, cursor visible, bracket_paste_flag unknown.
+    child.emitStdout('%begin 1 2 1\n%0,0,0,0,1,0,0,1,1,0,0,\n%end 1 2 1\n');
+    await untilWrites(child, 2);
+    child.emitStdout('%begin 1 3 1\n$ \n%end 1 3 1\n');
+    await started;
+
+    expect(seeds).toEqual(['\x1b[?1000h\x1b[?1006h', '$ ', '\x1b[1;1H']);
   });
 
   it('opens the output gate even when the seed capture errors', async () => {


### PR DESCRIPTION
Fixes #180

## Problem
A Terminal reattached after a Switch or reload gets its content, cursor, and
alt-screen state seeded into the new xterm, but not the terminal *modes* the
running TUI set once at startup — so the fresh xterm comes up with mouse
tracking off and clicks never reach the process. The post-seed SIGWINCH
repaint (`repaintAfterSeed`) doesn't help: TUIs redraw on resize but don't
re-send DECSET modes.

## Fix
Read tmux's per-pane mode flags (`mouse_standard/button/all/sgr_flag`,
`cursor_flag`, `keypad_cursor_flag`, `keypad_flag`, `bracket_paste_flag`) in
the `list-panes -F` that already discovers the pane id, and replay the set
ones into xterm before the captured frame — the same technique iTerm2 uses on
attach (`sources/tmux/TmuxStateParser.m`, `TmuxWindowOpener.m`). Generic:
applies to any TUI, nothing app-specific. Comma-separated format so a tmux
lacking a flag yields an empty field instead of shifting the rest.

## Verification
- Unit tests pin the seed order (`modes → frame → CUP`) plus the empty-field
  tolerance case; full suite passes (802 tests).
- tmux 3.7c: every flag tracks DECSET on/off; the built format round-trips
  through real `tmux -C` control mode.

ADR-0012 decision 5 amended with one paragraph.
